### PR TITLE
Allow current ruby and jruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.1', :engine => 'jruby', :engine_version => '9.1.8.0'
+ruby '>= 2.3.1', :engine => 'jruby', :engine_version => '>= 9.1.8.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'


### PR DESCRIPTION
The guide instructs the user to install jruby 9.1.17.0, so this Gemfile causes an error in the 'declare app dependencies' step. 

The guide also doesn't specify installing Ruby 2.3.1, so the Gemfile should not either. (no issues through at least Ruby 2.5.3)