### PR TITLE
add package.json to root of repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "jruby-getting-started-guide"
+}


### PR DESCRIPTION
The JRuby getting started guide fails when building with `pack build` and the latest heroku-24 builder. The error comes from the image being generated missing a js run time. The node js buildpack is responsible for that run time but it does not get triggered because this repo is not recognized as one that will run on node. Thus, adding a package.json, with a project name that abides by node js naming convention, signifying that this is a node package will trigger the detection.

Resolves #26 