### PR TITLE
Update Jruby and generate bin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
-/bin
 
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.1.0', engine: 'jruby', engine_version: '9.4.1.0'
+ruby '3.1.4', engine: 'jruby', engine_version: '9.4.7.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 7.0.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
 PLATFORMS
   java
   universal-java-19
+  universal-java-22
   x86_64-linux
 
 DEPENDENCIES
@@ -237,7 +238,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 3.1.0p0 (jruby 9.4.1.0)
+   ruby 3.1.4p0 (jruby 9.4.7.0)
 
 BUNDLED WITH
    2.4.7

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative "../config/boot"
+require "rake"
+Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+require "fileutils"
+
+# path to your application root.
+APP_ROOT = File.expand_path("..", __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
+  # Add necessary setup steps to this file.
+
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?("config/database.yml")
+  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
+  # end
+
+  puts "\n== Preparing database =="
+  system! "bin/rails db:prepare"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! "bin/rails log:clear tmp:clear"
+
+  puts "\n== Restarting application server =="
+  system! "bin/rails restart"
+end


### PR DESCRIPTION
The Ruby CNB expects `bin/rails` to exist, but it's missing in this repo. I generated them by running:

```
$ bundle exec rake app:update:bin
      create  bin
      create  bin/rails
      create  bin/rake
      create  bin/setup
```

This missing `bin/rails` was noticed in https://github.com/heroku/jruby-getting-started/issues/27#issuecomment-2173897251.